### PR TITLE
Update made to dashboard url in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ dependencies{
 
 ## Usage
 
-The SDK needs to be initialized with your app username and API key, which you get from the [dashboard](https://account/africastalking.com).
+The SDK needs to be initialized with your app username and API key, which you get from the [dashboard](https://account.africastalking.com).
 
 > You can use this SDK for either production or sandbox apps. For sandbox, the app username is **ALWAYS** `sandbox`
 


### PR DESCRIPTION
Typo fixes from (https://account/africastalking.com). to (https://account.africastalking.com).