### PR TITLE
Add requester to Payments B2B

### DIFF
--- a/libs/payment/src/main/java/com/africastalking/payment/recipient/Business.java
+++ b/libs/payment/src/main/java/com/africastalking/payment/recipient/Business.java
@@ -31,6 +31,7 @@ public final class Business {
     public String transferType;
     public String destinationChannel;
     public String destinationAccount = null;
+    public String requester = null;
     public HashMap<String, String> metadata = new HashMap<>();
 
     /**
@@ -40,16 +41,18 @@ public final class Business {
      * @param destinationChannel Name or number of the channel that will receive payment by the provider.
      *                           e.g. Mobile Provider's Paybill or Buy Goods number that belongs to the business.
      * @param destinationAccount Account name used by the business to receive money on the provided @{param destinationAccount}.
+     * @param requester PhoneNumber through which KPLC will send tokens when using B2B to buy electricity tokens.
      * @param transferType Nature of transaction. e.g. {@link com.africastalking.payment.recipient.Business Business.TRANSFER_TYPE_BUYGOODS}
      * @param provider Payment Provider. e.g. {@link com.africastalking.payment.recipient.Business Business.PROVIDER_MPESA}
      * @param amount Amount to transact, along with the currency code. e.g. USD 3435
      */
-    public Business(String destinationChannel, String destinationAccount, String transferType, String provider, String curencyCode, float amount) {
+    public Business(String destinationChannel, String destinationAccount, String requester, String transferType, String provider, String curencyCode, float amount) {
         this.amount = amount;
         this.provider = provider;
         this.currencyCode = curencyCode;
         this.transferType = transferType;
         this.destinationChannel = destinationChannel;
+        this.requester = requester;
         this.destinationAccount = destinationAccount;
     }
 


### PR DESCRIPTION


We recently updated the B2B API to enable clients pay for tokens.

The new B2B API has a new field in the request body called requester which allows insertion of a phone number through which KPLC will send tokens.

```
{
  "username": "username",
  "productName": "productname",
  "provider" : "Mpesa",
  "transferType": "BusinessPaybill",
    "currencyCode": "KES",
       "amount": 100,
       "destinationChannel" : "888880", 
       "destinationAccount": "01450717531", 
       "requester":"2547XX...",
      "metadata": {
        "shopId": "1234",
        "itemId": "abcdef"
      }
}
```
