### PR TITLE
Update set up instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ resolvers += "africastalking maven repository" at "http://dl.bintray.com/africas
 libraryDependencies += "com.africastalking" % "core" % "3.4.6"
 ```
 
-or Gradle:
+or Gradle (Groovy DSL):
 ```groovy
 repositories {
   maven {
@@ -48,7 +48,7 @@ repositories {
 
 dependencies{
   // Get all services
-  compile 'com.africastalking:core:3.4.6'
+  implementation 'com.africastalking:core:3.4.6'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ dependencies{
 }
 ```
 
+or Gradle (Kotlin DSL):
+```kotlin
+repositories {
+    jcenter()
+    maven { setUrl("http://dl.bintray.com/africastalking/java") }
+}
+
+dependencies{
+  // Get all services
+  implementation("com.africastalking:core:3.4.6")
+}
+```
+
 ## Usage
 
 The SDK needs to be initialized with your app username and API key, which you get from the [dashboard](https://account.africastalking.com).


### PR DESCRIPTION
Just a little house keeping, for Gradle, compile was deprecated and replaced with implementation. From the Gradle docs [here](https://docs.gradle.org/current/userguide/java_plugin.html):
>**compile(Deprecated)**
Compile time dependencies. Superseded by implementation.

>**implementation extends compile**
Implementation only dependencies.

Also added Kotlin DSL for Gradle. 😄 